### PR TITLE
feat: prior to localhost

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = {
 
     if (moduleFederationConfigPath) {
       const moduleFederationConfig = require(moduleFederationConfigPath);
-      
+
       webpackConfig.output.publicPath = "auto";
 
       if (pluginOptions?.useNamedChunkIds) {
@@ -46,16 +46,24 @@ module.exports = {
           ...moduleFederationConfig,
           shared: moduleFederationConfig.shared
             ? Object.fromEntries(
-                Object.entries(moduleFederationConfig.shared)
-                  .filter(([, value]) => Boolean(value.singleton))
-                  .map(([key, value]) => {
-                    const newValue = { ...value };
-                    if (process.env.NODE_ENV === "production") {
-                      newValue.requiredVersion = "*";
-                      newValue.version = "0";
+                Object.entries(moduleFederationConfig.shared).map(
+                  ([key, value]) => {
+                    if (
+                      typeof value === "object" &&
+                      !Array.isArray(value) &&
+                      value !== null &&
+                      value.singleton
+                    ) {
+                      const newValue = { ...value };
+                      if (process.env.NODE_ENV === "production") {
+                        newValue.requiredVersion = "*";
+                        newValue.version = "0";
+                      }
+                      return [key, newValue];
                     }
-                    return [key, newValue];
-                  })
+                    return [key, value];
+                  }
+                )
               )
             : null,
         }),

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ module.exports = {
     const moduleFederationConfigPath = getModuleFederationConfigPath();
 
     if (moduleFederationConfigPath) {
+      const moduleFederationConfig = require(moduleFederationConfigPath);
+      
       webpackConfig.output.publicPath = "auto";
 
       if (pluginOptions?.useNamedChunkIds) {
@@ -35,14 +37,28 @@ module.exports = {
       htmlWebpackPlugin.userOptions = {
         ...htmlWebpackPlugin.userOptions,
         publicPath: paths.publicUrlOrPath,
-        excludeChunks: [require(moduleFederationConfigPath).name],
+        excludeChunks: [moduleFederationConfig.name],
       };
 
       webpackConfig.plugins = [
         ...webpackConfig.plugins,
-        new webpack.container.ModuleFederationPlugin(
-          require(moduleFederationConfigPath)
-        ),
+        new webpack.container.ModuleFederationPlugin({
+          ...moduleFederationConfig,
+          shared: moduleFederationConfig.shared
+            ? Object.fromEntries(
+                Object.entries(moduleFederationConfig.shared)
+                  .filter(([, value]) => Boolean(value.singleton))
+                  .map(([key, value]) => {
+                    const newValue = { ...value };
+                    if (process.env.NODE_ENV === "production") {
+                      newValue.requiredVersion = "*";
+                      newValue.version = "0";
+                    }
+                    return [key, newValue];
+                  })
+              )
+            : null,
+        }),
       ];
 
       // webpackConfig.module = {


### PR DESCRIPTION
If you work with some modules from localhost and others from remotes, this PR is made for you.
Using remote modules makes shared singletons come from the remote, too, since it's the last to be loaded.

By forcing the version to 0, the production build will try to load the latest version, and localhost can load their shared dependencies (React in dev mode or our shared libraries)

More info here https://github.com/module-federation/module-federation-examples/issues/2311